### PR TITLE
Price Modifier: 'priceable_modifier' behavior

### DIFF
--- a/lib/pricing_definition/behaviours.rb
+++ b/lib/pricing_definition/behaviours.rb
@@ -1,4 +1,5 @@
 require 'pricing_definition/behaviours/priceable'
+require 'pricing_definition/behaviours/priceable_modifier'
 
 module PricingDefinition
   module Behaviours

--- a/lib/pricing_definition/behaviours/priceable_modifier.rb
+++ b/lib/pricing_definition/behaviours/priceable_modifier.rb
@@ -1,0 +1,13 @@
+require 'pricing_definition/behaviours/priceable_modifier/setup_methods'
+require 'pricing_definition/behaviours/priceable_modifier/instance_methods'
+
+module PricingDefinition
+  module Behaviours
+    module PriceableModifier
+      def self.included(klass)
+        klass.extend SetupMethods
+        klass.include InstanceMethods
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/behaviours/priceable_modifier/instance_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_modifier/instance_methods.rb
@@ -1,0 +1,56 @@
+require 'active_support/concern'
+require 'active_model'
+
+module PricingDefinition
+  module Behaviours
+    module PriceableModifier
+      module InstanceMethods
+        extend ActiveSupport::Concern
+
+        included do
+          include ActiveModel::Validations
+
+          validates :currency, presence: true, if: 'fixed?'
+          validates :amount, numericality: { only_integer: true, greater_than: 0 }
+          validates :amount, numericality: { less_than_or_equal_to: 100 }, unless: 'fixed?'
+
+          def serialized
+            { additive: additive,
+              amount: amount,
+              description: priceable_modifier_description,
+              label: priceable_modifier_label,
+              currency: (fixed ? currency : nil),
+              weight: priceable_modifier_weight
+            }.with_indifferent_access
+          end
+
+          private
+
+          def priceable_modifier_weight
+            priceable_modifier_options[:weight]
+          end
+
+          def priceable_modifier_label
+            string_or_delegate(priceable_modifier_options[:label])
+          end
+
+          def priceable_modifier_description
+            string_or_delegate(priceable_modifier_options[:description])
+          end
+
+          def string_or_delegate(arg)
+            if arg.is_a?(String)
+              arg
+            elsif arg.is_a?(Symbol) && respond_to?(arg)
+              send(arg)
+            end
+          end
+
+          def priceable_modifier_options
+            self.class.send(:options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/behaviours/priceable_modifier/setup_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_modifier/setup_methods.rb
@@ -1,0 +1,57 @@
+module PricingDefinition
+  module Behaviours
+    module PriceableModifier
+      module SetupMethods
+
+        ALLOWED_OPTION_KEYS  = [:for, :weight, :label, :description].freeze
+        REQUIRED_OPTION_KEYS = [:weight, :label, :description].freeze
+        REQUIRED_ATTRIBUTES  = [:fixed, :currency, :amount, :additive].freeze
+
+        def priceable_modifier(options = {})
+          @options = options.freeze
+          validate_options!
+          ensure_required_attributes!
+          setup_config!
+        end
+
+        private
+
+        attr_reader :options
+
+        def setup_config!
+          config.set! :priceable_modifier, self, options
+        end
+
+        def validate_options!
+          ensure!("Invalid options for priceable modifier") do
+            (options.keys - ALLOWED_OPTION_KEYS).empty?
+          end
+
+          ensure!("Not all required options are present") do
+            (REQUIRED_OPTION_KEYS - options.keys).empty?
+          end
+
+          ensure!("Nil options are not allowed") do
+            options.values.none? { |v| v.nil? }
+          end
+        end
+
+        def ensure_required_attributes!
+          ensure!("Not all required attributes are present") do
+            REQUIRED_ATTRIBUTES.all? { |attr| attribute_names.include?(attr.to_s) }
+          end
+        end
+
+        def ensure!(error_message, &block)
+          unless yield(block)
+            raise ArgumentError, error_message
+          end
+        end
+
+        def config
+          PricingDefinition::Configuration
+        end
+      end
+    end
+  end
+end

--- a/spec/pricing_definition/behaviours/priceable_modifier/instance_methods_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_modifier/instance_methods_spec.rb
@@ -1,0 +1,163 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Behaviours
+    describe PriceableModifier do
+      let(:klass) { ::ModifierWithRequiredAttributes }
+      let(:options) { base_options }
+      let(:base_options) { { weight: 10, label: :label, description: :description } }
+
+      before(:each) do
+        klass.priceable_modifier(options)
+      end
+
+      describe '#serialized' do
+        subject { instance.serialized }
+        let(:instance) { klass.new }
+        let(:amount) { 50 }
+        let(:additive) { false }
+        let(:fixed) { false }
+        let(:label) { double('label') }
+        let(:description) { double('description') }
+
+        before(:each) do
+          allow(instance).to receive(:additive).and_return(additive)
+          allow(instance).to receive(:amount).and_return(amount)
+          allow(instance).to receive(:fixed).and_return(fixed)
+          allow(instance).to receive(:label).and_return(label)
+          allow(instance).to receive(:description).and_return(description)
+        end
+
+        it 'contains :additive, :amount and :weight' do
+          expect(subject).to include(additive: false)
+          expect(subject).to include(amount: 50)
+          expect(subject).to include(weight: options[:weight])
+        end
+
+        context 'with description option' do
+          context 'being a string' do
+            let(:options) { base_options.merge(description: description) }
+            let(:description) { 'some description' }
+
+            it 'includes the provided string' do
+              expect(subject[:description]).to eq(description)
+            end
+          end
+
+          context 'being a symbol' do
+            let(:options) { base_options.merge(description: :description) }
+            let(:description) { 'result of description method' }
+
+            it 'includes the result of the corresponding method' do
+              expect(subject[:description]).to eq(description)
+            end
+          end
+        end
+
+        context 'with label option' do
+          context 'being a string' do
+            let(:options) { base_options.merge(label: label) }
+            let(:label) { 'some label' }
+
+            it 'includes the provided string' do
+              expect(subject[:label]).to eq(label)
+            end
+          end
+
+          context 'being a symbol' do
+            let(:options) { base_options.merge(label: :label) }
+            let(:label) { 'result of label method' }
+
+            it 'includes the result of the corresponding method' do
+              expect(subject[:label]).to eq(label)
+            end
+          end
+        end
+
+        context 'with modifier type' do
+          before(:each) do
+            allow(instance).to receive(:fixed).and_return(fixed)
+          end
+
+          context 'being fixed' do
+            let(:currency) { :eur }
+            let(:fixed) { true }
+
+            it 'includes currency information' do
+              allow(instance).to receive(:currency).and_return(currency)
+              expect(subject[:currency]).to eq(currency)
+            end
+          end
+
+          context 'being non fixed' do
+            let(:fixed) { false }
+
+            it 'does not include currency information' do
+              expect(subject[:currency]).to be_nil
+            end
+          end
+        end
+      end
+
+      describe '#save' do
+        subject { instance.save! }
+
+        context 'with amount being less or equal to zero' do
+          let(:instance) { klass.new amount: 0 }
+
+          it 'raises an ActiveRecord::Invalid error' do
+            expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(instance.errors.keys).to include(:amount)
+          end
+        end
+
+        context 'with :fixed being false' do
+          let(:instance) { klass.new amount: amount, fixed: fixed }
+          let(:fixed) { false }
+
+          context 'and amount greater than 100' do
+            let(:amount) { 101 }
+
+            it 'does not raise an ActiveRecord::RecordInvalid error' do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(instance.errors.keys).to include(:amount)
+              expect(instance.errors[:amount]).to include("must be less than or equal to 100")
+            end
+          end
+
+          context 'and amount less than or equal to 100' do
+            let(:amount) { 100 }
+
+            it 'does not raise an error' do
+              expect { subject }.to_not raise_error
+            end
+          end
+        end
+
+        context 'with :fixed being true' do
+          let(:instance) { klass.new currency: currency, fixed: fixed }
+          let(:fixed) { true }
+
+          context 'and currency not present' do
+            let(:currency) { nil }
+
+            it 'raises an ActiveRecord::InvalidRecord error' do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+              expect(instance.errors.keys).to include(:currency)
+            end
+          end
+
+          context 'and currency present' do
+            let(:currency) { 'usd' }
+
+            it 'does not raise an error' do
+              expect { subject }.to_not raise_error
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pricing_definition/behaviours/priceable_modifier_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_modifier_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Behaviours
+    describe PriceableModifier do
+      subject { klass.priceable_modifier(options) }
+      let(:klass) { ::ModifierWithRequiredAttributes }
+
+      context 'priceable modifier behaviour declaration' do
+        context 'with invalid option keys' do
+          let(:options) { { unsupported: :configuration } }
+
+          it 'does not raise an error' do
+            expect { subject }.to raise_error
+          end
+        end
+
+        context 'with valid option keys' do
+          let(:behaviour) { PricingDefinition::Configuration.behaviour_for(klass) }
+          let(:options) { { for: :priceable, label: 'Discount', description: 'Free beer!', weight: 10 } }
+
+          it 'does not raise an error' do
+            expect { subject }.to_not raise_error
+          end
+
+          it 'adds update configuration for priceable modifiers' do
+            subject
+            expect(behaviour).to eq(:priceable_modifier)
+          end
+        end
+      end
+
+      context 'host model validation' do
+        subject { klass.priceable_modifier(options) }
+        let(:options) { { label: 'Discount', description: 'Free beer!', weight: 10 } }
+
+        context 'with required defined attributed' do
+          let(:klass) { ::ModifierWithRequiredAttributes }
+
+          it 'does not raise an error' do
+            expect { subject }.to_not raise_error
+          end
+        end
+
+        context 'with required defined attributed' do
+          let(:klass) { ::ModifierWithoutRequiredAttributes }
+
+          it 'raises an error' do
+            expect { subject }.to raise_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -21,6 +21,18 @@ ActiveRecord::Schema.define do
     t.integer :max_limit, default: nil
     t.timestamps null: false
   end
+
+  create_table :modifier_without_required_attributes, force: true do |t|
+    t.timestamps null: false
+  end
+
+  create_table :modifier_with_required_attributes, force: true do |t|
+    t.boolean :additive, default: false
+    t.boolean :fixed, default: false
+    t.integer :amount, default: 1
+    t.string :currency
+    t.timestamps null: false
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -9,14 +9,14 @@ class Priceable < ActiveRecord::Base
 end
 
 def create_definition!(args = {})
-  PricingDefinition::Resources::Definition.create! default_args.merge(args)
+  PricingDefinition::Resources::Definition.create! default_price_definition_args.merge(args)
 end
 
 def build_definition(args = {})
-  PricingDefinition::Resources::Definition.new default_args.merge(args)
+  PricingDefinition::Resources::Definition.new default_price_definition_args.merge(args)
 end
 
-def default_args
+def default_price_definition_args
   {
     definition: {
       '1+' => {
@@ -27,4 +27,12 @@ def default_args
     },
     priceable: TestPriceable.create!(min_limit: 1, max_limit: 20)
   }
+end
+
+class ModifierWithoutRequiredAttributes < ActiveRecord::Base
+  include PricingDefinition::Behaviours::PriceableModifier
+end
+
+class ModifierWithRequiredAttributes < ActiveRecord::Base
+  include PricingDefinition::Behaviours::PriceableModifier
 end


### PR DESCRIPTION
> This spec attempts to clarify and further detail the initial draft of the `priceable_modifier` behavior defined in https://github.com/anyroadcom/anyroad/issues/657
# Definition

Models that act as `priceable_modifier` **must** have the following attributes defined:

| Attribute | Type | Description |
| --- | --- | --- |
| `fixed` | boolean | `true` if modifier is used for fixed amount, `false` if used for percentage |
| `amount` | integer | absolute value for the modifier, in cents if type is `fixed` or percents if `percentage` |
| `currency` | string | currency in which the modifier is applied. Used only when type is `fixed` |
| `additive` | boolean | indicates the operation type: `true` if modifier adds to the price, `false` otherwise |
# Configuration

When declaring the `priceable_modifier` behaviour on a model, the following configuration options are available:
- `label` - String or Symbol. If string, use that as the label for the modifier. If symbol, delegate to the indicated method to retrieve the value
- `description` - Same as above, for description
- `for` - Symbol or Array. Indicate the base priceable(s) that the modifier applies to.
- `weight` - Integer which will determine the order in which it is applied, when multiple modifiers are being used in the calculation.
# Validations

When applied inside a host model, the `priceable_modifier` behaviour will trigger the following validations: 
##### Structural validations
- All the required attributes are defined
- `label`, `description` & `weight` options are always is defined
##### Instance validations
- `amount` between 0 and 100 if `type = "percentage"`
- `amount` greater than 0 if `type = "fixed"`
- `currency` not empty if `type = "fixed"`
- `label`, `description`, `additive` not null
- `label` and `description` - check that method exists if symbols were provided in the config
# Serialization

The behaviour adds the `for_calculator` method to the host model. The output will be a `Hash` (or `HashWithIndifferentAccess`) that includes all the attributes in the definition.
##### Subtractive

``` javascript
{
  label: "10+ Participants Discount",
  description: "Up to 100$ discount on bookings with over 10 participants",
  fixed: true,
  amount: 100,
  currency: "usd",
  additive: false
}
```
##### Aditive

``` javascript
{
  label: "16% VAT",
  description: "16% VAT, as the name implies",
  fixed: false,
  amount: 16,
  currency: null,
  additive: true
}
```
# Usage

To use the `priceable_modifier` functionality in a model, you need to include the `PricingDefinition::Behaviors::PriceableModifier` and declare it as such, while specifying it's configuration options:

``` ruby
  include PricingDefinition::Behaviours::PriceableModifier
  priceable_modifier for: :tour, label: :code, description: :message_to_tourist
```
# Example

``` ruby
class Discount < ActiveRecord::Base
  # attr :modifier_type, :string # ENUM(fixed, percentage)
  # attr :additive, :boolean # false
  # attr :amount, :integer # 40 (%), 10000 (cents)
  WEIGHT = 10

  include PricingDefinition::Behaviours::PriceableModifier
  priceable_modifier for: :tour, label: :code, description: :message_to_tourist
end

class Tax < ActiveRecord::Base
  # attr :modifier_type, :string # ENUM(fixed, percentage)
  # attr :additive, :boolean # true
  # attr :amount, :integer # 40 (%), 10000 (cents)
  WEIGHT = 5

  include PricingDefinition::Behaviours::PriceableModifier
  priceable_modifier for: :tour, label: 'VAT (25%)', description: :legal_notice
end
```
