### PR TITLE
Priceable Calculator behaviour

### DIFF
--- a/lib/pricing_definition.rb
+++ b/lib/pricing_definition.rb
@@ -2,6 +2,7 @@ require "pricing_definition/configuration"
 require "pricing_definition/version"
 require "pricing_definition/behaviours"
 require "pricing_definition/resources"
+require "pricing_definition/helpers/calculator"
 
 module PricingDefinition
 end

--- a/lib/pricing_definition.rb
+++ b/lib/pricing_definition.rb
@@ -2,7 +2,7 @@ require "pricing_definition/configuration"
 require "pricing_definition/version"
 require "pricing_definition/behaviours"
 require "pricing_definition/resources"
-require "pricing_definition/helpers/calculator"
+require "pricing_definition/helpers"
 
 module PricingDefinition
 end

--- a/lib/pricing_definition/behaviours.rb
+++ b/lib/pricing_definition/behaviours.rb
@@ -1,4 +1,5 @@
 require 'pricing_definition/behaviours/priceable'
+require 'pricing_definition/behaviours/priceable_calculator'
 require 'pricing_definition/behaviours/priceable_modifier'
 
 module PricingDefinition

--- a/lib/pricing_definition/behaviours/priceable/instance_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable/instance_methods.rb
@@ -2,8 +2,12 @@ module PricingDefinition
   module Behaviours
     module Priceable
       module InstanceMethods
-        def pricing_definition
-          pricing_definitions.available.prioritized.first
+        def pricing_definition(interval = nil)
+          if interval.present? && !interval.is_a?(Date)
+            raise ArgumentError, "interval provided must be a Date"
+          else
+            pricing_definitions.available(interval).prioritized.first
+          end
         end
 
         def has_default_pricing_definition?

--- a/lib/pricing_definition/behaviours/priceable/setup_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable/setup_methods.rb
@@ -3,7 +3,7 @@ module PricingDefinition
     module Priceable
       module SetupMethods
 
-        ALLOWED_OPTION_KEYS = [:addon_for]
+        ALLOWED_OPTION_KEYS = [:addon_for, :currency]
 
         def priceable(options = {})
           @options = options

--- a/lib/pricing_definition/behaviours/priceable_calculator.rb
+++ b/lib/pricing_definition/behaviours/priceable_calculator.rb
@@ -1,0 +1,15 @@
+require 'pricing_definition/behaviours/priceable_calculator/class_methods'
+require 'pricing_definition/behaviours/priceable_calculator/instance_methods'
+require 'pricing_definition/behaviours/priceable_calculator/setup_methods'
+
+module PricingDefinition
+  module Behaviours
+    module PriceableCalculator
+      def self.included(klass)
+        klass.send :extend, SetupMethods
+        klass.send :extend, ClassMethods
+        klass.send :include, InstanceMethods
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/behaviours/priceable_calculator/class_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_calculator/class_methods.rb
@@ -1,0 +1,15 @@
+module PricingDefinition
+  module Behaviours
+    module PriceableCalculator
+      module ClassMethods
+        def pricing_parties
+          @pricing_parties ||= priceable_calculator_config.parties
+        end
+
+        def pricing_party_names
+          pricing_parties.keys
+        end
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/behaviours/priceable_calculator/instance_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_calculator/instance_methods.rb
@@ -1,0 +1,19 @@
+module PricingDefinition
+  module Behaviours
+    module PriceableCalculator
+      module InstanceMethods
+        def priceable_calculator_party_modifiers
+          self.class.pricing_party_names.each_with_object({}) do |party_name, obj|
+            obj[party_name] = priceable_calculator_modifiers
+          end
+        end
+
+        def priceable_calculator_modifiers
+          self.class.send(:priceable_calculator_config).priceable_modifiers.map do |mod|
+            self.send(mod).serialized
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/behaviours/priceable_calculator/instance_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_calculator/instance_methods.rb
@@ -2,16 +2,12 @@ module PricingDefinition
   module Behaviours
     module PriceableCalculator
       module InstanceMethods
-        def priceable_calculator_party_modifiers
-          self.class.pricing_party_names.each_with_object({}) do |party_name, obj|
-            obj[party_name] = priceable_calculator_modifiers
-          end
+        def calculator
+          Helpers::Calculator.new(self)
         end
 
-        def priceable_calculator_modifiers
-          self.class.send(:priceable_calculator_config).priceable_modifiers.map do |mod|
-            self.send(mod).serialized
-          end
+        def calculator_config
+          @calculator_config ||= self.class.priceable_calculator_config
         end
       end
     end

--- a/lib/pricing_definition/behaviours/priceable_calculator/setup_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_calculator/setup_methods.rb
@@ -1,0 +1,107 @@
+require 'ostruct' unless defined?(OpenStruct)
+
+module PricingDefinition
+  module Behaviours
+    module PriceableCalculator
+      module SetupMethods
+
+       ALLOWED_OPTION_KEYS = [:priceable, :priceable_addons, :priceable_modifiers, :interval_start, :volume]
+       OPTIONS_TO_DELEGATE = [:volume, :interval_start, :priceable]
+
+        class Configure
+          @options = { parties: {} }
+
+          class << self
+            def options
+              @options.dup.freeze
+            end
+
+            def add_party(party_name, opts = {})
+              @options[:parties][party_name] = opts.freeze
+            end
+          end
+        end
+
+        def priceable_calculator(options = {}, &block)
+          @priceable_calculator_options = options.freeze
+          @priceable_calculator_config_block = block
+
+          validate_options!
+          validate_config_block!
+          setup_config!
+          setup_instance_methods
+
+          has_one :pricing_payment, class_name: 'PricingDefinition::Resources::Payment', as: :priceable_calculator, dependent: :nullify
+        end
+
+        def validate_options!
+          ensure!("Invalid options keys for priceable calculator") do
+            (priceable_calculator_options.keys - ALLOWED_OPTION_KEYS).empty?
+          end
+
+          ensure!("Missing required attributes for priceable calculator") do
+            OPTIONS_TO_DELEGATE.all? { |attr| self.new.respond_to?(priceable_calculator_options[attr]) }
+          end
+
+          ensure!("Priceable is not valid or is an addon for another priceable") do
+            priceable_valid? && primary_priceable?
+          end
+        end
+
+        def validate_config_block!
+          ensure!("You need to provide a configuration block") do
+            priceable_calculator_config_block.is_a?(Proc)
+          end
+        end
+
+        private
+
+        attr_reader :priceable_calculator_options, :priceable_calculator_config_block
+
+        def setup_config!
+          priceable_calculator_config_block.call(Configure)
+          options = priceable_calculator_options.merge(Configure.options)
+          pricing_config.set! :priceable_calculator, self, options
+        end
+
+        def setup_instance_methods
+          OPTIONS_TO_DELEGATE.each do |attr|
+            define_method "pricing_#{attr}" do
+              send self.class.send(:priceable_calculator_options)[attr]
+            end
+          end
+        end
+
+        def pricing_config
+          PricingDefinition::Configuration
+        end
+
+        def ensure!(error_message, &block)
+          unless yield(block)
+            raise ArgumentError, error_message
+          end
+        end
+
+        def primary_priceable?
+          priceable_config.try(:addon_for).nil?
+        end
+
+        def priceable_valid?
+          pricing_config.behaviour_for(priceable_klass) == :priceable
+        end
+
+        def priceable_klass
+          @priceable ||= priceable_calculator_options[:priceable].to_s.camelize.constantize
+        end
+
+        def priceable_config
+          @priceable_config ||= pricing_config.get(:priceable, priceable_klass)
+        end
+
+        def priceable_calculator_config
+          @priceable_calculator_config ||= pricing_config.get(:priceable_calculator, self)
+        end
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/behaviours/priceable_calculator/setup_methods.rb
+++ b/lib/pricing_definition/behaviours/priceable_calculator/setup_methods.rb
@@ -27,7 +27,7 @@ module PricingDefinition
           @priceable_calculator_config_block = block
 
           validate_options!
-          validate_config_block!
+          validate_configuration!
           setup_config!
           setup_instance_methods
 
@@ -35,7 +35,7 @@ module PricingDefinition
         end
 
         def validate_options!
-          ensure!("Invalid options keys for priceable calculator") do
+          ensure!("Invalid option keys for priceable calculator") do
             (priceable_calculator_options.keys - ALLOWED_OPTION_KEYS).empty?
           end
 
@@ -48,10 +48,14 @@ module PricingDefinition
           end
         end
 
-        def validate_config_block!
+        def validate_configuration!
           ensure!("You need to provide a configuration block") do
             priceable_calculator_config_block.is_a?(Proc)
           end
+        end
+
+        def priceable_calculator_config
+          @priceable_calculator_config ||= pricing_config.get(:priceable_calculator, self)
         end
 
         private
@@ -96,10 +100,6 @@ module PricingDefinition
 
         def priceable_config
           @priceable_config ||= pricing_config.get(:priceable, priceable_klass)
-        end
-
-        def priceable_calculator_config
-          @priceable_calculator_config ||= pricing_config.get(:priceable_calculator, self)
         end
       end
     end

--- a/lib/pricing_definition/helpers.rb
+++ b/lib/pricing_definition/helpers.rb
@@ -1,0 +1,8 @@
+require "pricing_definition/helpers/calculator"
+
+module PricingDefinition
+  module Helpers
+
+  end
+end
+

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/module/delegation'
-require 'pricing_definition/helpers/calculator/party'
+require "pricing_definition/helpers/calculator/party"
+require "pricing_definition/helpers/calculator/pricing_rule"
 
 module PricingDefinition
   module Helpers

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -39,6 +39,10 @@ module PricingDefinition
         priceable.pricing_definition(interval_start)
       end
 
+      def pricing_rule
+        pricing_definition.for_volume(overall_volume)
+      end
+
       def currencies
         parties.map { |p| p.currency.downcase.to_sym }
       end

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -44,10 +44,6 @@ module PricingDefinition
         pricing_definition.for_volume(overall_volume)
       end
 
-      def currencies
-        parties.map { |p| p.currency.downcase.to_sym }
-      end
-
       def modifiers
         config_priceable_modifiers.map do |modifier|
           resource.send(modifier)

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -53,7 +53,8 @@ module PricingDefinition
       def setup_parties!
         config_parties.each do |name, options|
           party_options = { name: name }.merge(options)
-          (@parties ||= []) << Calculator::Party.new(resource, party_options)
+          party_resource = (options[:source] == :self) ? resource : resource.send(name)
+          (@parties ||= []) << Calculator::Party.new(party_resource, party_options)
         end
       end
     end

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -1,38 +1,59 @@
 require 'active_support/core_ext/module/delegation'
+require 'pricing_definition/helpers/calculator/party'
 
 module PricingDefinition
   module Helpers
     class Calculator
+      attr_reader :resource, :parties
 
-      attr_reader :resource
-
-      delegate :parties, :priceable_modifiers, to: 'resource.calculator_config'
+      delegate :calculator_config, to: :resource
+      delegate :parties, :priceable_modifiers, to: :calculator_config, prefix: :config
 
       def initialize(resource = nil)
         @resource = resource
+        setup_parties!
       end
 
-      def priceable
-        resource.send(resource.calculator_config.priceable)
+      [:priceable, :interval_start, :volume].each do |method_name|
+        define_method method_name do
+          resource.send calculator_config.send(method_name)
+        end
+      end
+
+      def overall_volume
+        volume.map { |label, quantity| quantity }.compact.reduce(:+)
       end
 
       def pricing_definition
-        priceable.pricing_definition
+        priceable.pricing_definition(interval_start)
+      end
+
+      def base_currency
+        base_party.currency
       end
 
       def modifiers
-        priceable_modifiers.map do |modifier|
+        config_priceable_modifiers.map do |modifier|
           resource.send(modifier)
-        end
+        end.compact
       end
 
       def parties_modifiers
         if resource.respond_to?(:parties_modifiers)
           resource.send(:parties_modifiers)
         else
-          parties.keys.each_with_object({}) do |party_name, obj|
+          config_parties.keys.each_with_object({}) do |party_name, obj|
             obj[party_name] = modifiers
           end
+        end
+      end
+
+      private
+
+      def setup_parties!
+        config_parties.each do |name, options|
+          party_options = { name: name }.merge(options)
+          (@parties ||= []) << Calculator::Party.new(resource, party_options)
         end
       end
     end

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -68,8 +68,16 @@ module PricingDefinition
       def setup_parties!
         config_parties.each do |name, options|
           party_options = { name: name }.merge(options)
-          party_resource = (options[:source] == :self) ? resource : resource.send(name)
-          (@parties ||= []) << Calculator::Party.new(party_resource, party_options)
+          party_objects = party_resource(name, options[:source])
+          (@parties ||= []) << Calculator::Party.new(party_objects, party_options)
+        end
+      end
+
+      def party_resource(name, source)
+        case source
+        when :self then resource
+        when nil then resource.send(name)
+        else resource.send(source)
         end
       end
     end

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -1,0 +1,40 @@
+require 'active_support/core_ext/module/delegation'
+
+module PricingDefinition
+  module Helpers
+    class Calculator
+
+      attr_reader :resource
+
+      delegate :parties, :priceable_modifiers, to: 'resource.calculator_config'
+
+      def initialize(resource = nil)
+        @resource = resource
+      end
+
+      def priceable
+        resource.send(resource.calculator_config.priceable)
+      end
+
+      def pricing_definition
+        priceable.pricing_definition
+      end
+
+      def modifiers
+        priceable_modifiers.map do |modifier|
+          resource.send(modifier)
+        end
+      end
+
+      def parties_modifiers
+        if resource.respond_to?(:parties_modifiers)
+          resource.send(:parties_modifiers)
+        else
+          parties.keys.each_with_object({}) do |party_name, obj|
+            obj[party_name] = modifiers
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pricing_definition/helpers/calculator.rb
+++ b/lib/pricing_definition/helpers/calculator.rb
@@ -14,9 +14,20 @@ module PricingDefinition
         setup_parties!
       end
 
+      # Define delegator methods for @resource attributes
       [:priceable, :interval_start, :volume].each do |method_name|
         define_method method_name do
           resource.send calculator_config.send(method_name)
+        end
+      end
+
+      [:base, :charge].each do |attr|
+        define_method("#{attr}_party") do
+          parties.detect { |p| p.send("#{attr}?") }
+        end
+
+        define_method("#{attr}_currency") do
+          send("#{attr}_party").try(:currency)
         end
       end
 
@@ -28,8 +39,8 @@ module PricingDefinition
         priceable.pricing_definition(interval_start)
       end
 
-      def base_currency
-        base_party.currency
+      def currencies
+        parties.map { |p| p.currency.downcase.to_sym }
       end
 
       def modifiers

--- a/lib/pricing_definition/helpers/calculator/party.rb
+++ b/lib/pricing_definition/helpers/calculator/party.rb
@@ -1,0 +1,37 @@
+module PricingDefinition
+  module Helpers
+    class Calculator
+      class Party < OpenStruct
+
+        TYPE_BASE = :base
+        TYPE_CHARGE = :charge
+
+        def initialize(*args)
+          @resource, @options = args[0], args[1]
+          super(args[1])
+        end
+
+        [:base, :charge].each do |method_name|
+          define_method("#{method_name}?") do
+            type == eval("TYPE_#{method_name}".upcase)
+          end
+        end
+
+        [:title, :currency].each do |attr|
+          define_method(attr) do
+            delegate_or_value(attr)
+          end
+        end
+
+        private
+
+        attr_reader :resource, :options
+
+        def delegate_or_value(attr)
+          options[attr].is_a?(String) ? options[attr] : resource.send(options[attr])
+        end
+      end
+    end
+  end
+end
+

--- a/lib/pricing_definition/helpers/calculator/pricing_rule.rb
+++ b/lib/pricing_definition/helpers/calculator/pricing_rule.rb
@@ -9,7 +9,7 @@ module PricingDefinition
         end
 
         def fixed?
-          rule[:pricing][:fixed] == true
+          pricing[:fixed] == true
         end
 
         def deposit

--- a/lib/pricing_definition/helpers/calculator/pricing_rule.rb
+++ b/lib/pricing_definition/helpers/calculator/pricing_rule.rb
@@ -1,0 +1,40 @@
+require 'money'
+
+module PricingDefinition
+  module Helpers
+    class Calculator
+      class PricingRule
+        def initialize(rule = {})
+          @rule = rule
+        end
+
+        def fixed?
+          rule[:pricing][:fixed] == true
+        end
+
+        def deposit
+          @deposit ||= Money.new(pricing.deposit, currency)
+        end
+
+        def prices
+          @prices ||= pricing.price.each_with_object({}) do |pair, obj|
+            obj[pair[0]] = Money.new(pair[1], currency)
+          end
+        end
+
+        def currency
+          @currency ||= rule[:currency]
+        end
+
+        private
+
+        attr_reader :rule
+
+        def pricing
+          @pricing ||= OpenStruct.new(rule[:pricing])
+        end
+      end
+    end
+  end
+end
+

--- a/lib/pricing_definition/resources/definition.rb
+++ b/lib/pricing_definition/resources/definition.rb
@@ -65,6 +65,7 @@ module PricingDefinition
           if d[0].cover?(volume)
             h[:volume] = d[0]
             h[:pricing] = d[1]
+            h[:currency] = :eur
             return h
           else
             next
@@ -205,7 +206,8 @@ module PricingDefinition
 
       def definition_schema
         definition.each do |volume, pricing|
-          #errors.add :definition, :invalid_schema unless valid_schema?(pricing)
+          # TODO: fix this at some point...
+          # errors.add :definition, :invalid_schema unless valid_schema?(pricing)
           errors.add :definition, :invalid_volume unless valid_volume?(volume)
         end
       end
@@ -219,14 +221,6 @@ module PricingDefinition
         RSchema.validate!(PRICING_SCHEMA, coerced_pricing)
       rescue
         false
-      end
-
-      def priceable_config
-        setup.detect { |p| p[:active_record] == priceable.class }
-      end
-
-      def setup
-        PricingDefinition::Configuration.setup[:priceables]
       end
 
       def normalize_errorneous_ranges

--- a/lib/pricing_definition/resources/definition.rb
+++ b/lib/pricing_definition/resources/definition.rb
@@ -65,7 +65,7 @@ module PricingDefinition
           if d[0].cover?(volume)
             h[:volume] = d[0]
             h[:pricing] = d[1]
-            h[:currency] = :eur
+            h[:currency] = priceable.send(priceable_config.currency)
             return h
           else
             next
@@ -227,6 +227,10 @@ module PricingDefinition
         @erroneous_ranges.each do |key, ranges|
           @erroneous_ranges[key] = ranges.uniq
         end
+      end
+
+      def priceable_config
+        Configuration.get(:priceable, priceable.class)
       end
     end
   end

--- a/lib/pricing_definition/resources/definition.rb
+++ b/lib/pricing_definition/resources/definition.rb
@@ -43,11 +43,11 @@ module PricingDefinition
       after_initialize :set_defaults
       after_validation :normalize_errorneous_ranges
 
-      def self.available
+      def self.available(interval = nil)
         predicates = []
         predicates << '(? BETWEEN starts_at AND ends_at)'
         predicates << '(starts_at IS NULL and ends_at IS NULL)'
-        where(predicates.join(' OR '), Time.now)
+        where(predicates.join(' OR '), interval || Time.now)
       end
 
       def definition_with_ranges(cached = true)

--- a/lib/pricing_definition/resources/payment.rb
+++ b/lib/pricing_definition/resources/payment.rb
@@ -1,0 +1,13 @@
+require 'active_record'
+
+module PricingDefinition
+  module Resources
+    class Payment < ActiveRecord::Base
+
+      self.table_name = 'pricing_payments'
+
+      belongs_to :priceable_calculator, polymorphic: true
+
+    end
+  end
+end

--- a/pricing_definition.gemspec
+++ b/pricing_definition.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", "~> 4.1"
   spec.add_dependency "activesupport", "~> 4.1"
   spec.add_dependency "rschema", "~> 0.1"
+  spec.add_dependency "money", "~> 6.5"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "pry", "~> 0.10"

--- a/spec/pricing_definition/behaviours/priceable/instance_methods_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable/instance_methods_spec.rb
@@ -9,28 +9,25 @@ module PricingDefinition
       let(:priceable_klass) { ::TestPriceable }
 
       describe '#has_default_pricing_definition?' do
-        let(:priceable) { priceable_klass.create! currency: :eur, min_limit: 1, max_limit: 4 }
+        subject { priceable.reload.has_default_pricing_definition? }
+        let(:priceable) { priceable_klass.create! }
 
         context 'with default pricing definition' do
-          before(:each) do
-            create_definition! priceable: priceable, starts_at: nil, ends_at: nil
-          end
-
           it 'returns true' do
-            expect(priceable.reload).to have_default_pricing_definition
+            create_definition! priceable: priceable, starts_at: nil, ends_at: nil
+            expect(subject).to eq(true)
           end
         end
 
         context 'without default pricing definition' do
           it 'returns false' do
-            expect(priceable.reload).to_not have_default_pricing_definition
+            expect(subject).to eq(false)
           end
         end
       end
 
       describe '#pricing_definitions' do
         subject { priceable.reload.pricing_definitions }
-
         let!(:priceable) { priceable_klass.create! currency: :eur, min_limit: 1, max_limit: 4 }
         let!(:high_priority) { create_definition! priceable: priceable, weight: 20, starts_at: '2015-01-01', ends_at: '2015-02-01' }
         let!(:low_priority) { create_definition! priceable: priceable, weight: 10 }
@@ -42,9 +39,8 @@ module PricingDefinition
       end
 
       describe '#pricing_definition' do
-        subject { priceable.pricing_definition }
-
-        let(:priceable) { priceable_klass.create! currency: :eur, min_limit: 1, max_limit: 4 }
+        subject { priceable.pricing_definition(interval) }
+        let!(:priceable) { priceable_klass.create! currency: :eur, min_limit: 1, max_limit: 4 }
         let!(:default_definition) { create_definition! priceable: priceable, weight: 0 }
 
         around(:each) do |example|
@@ -53,49 +49,80 @@ module PricingDefinition
           Timecop.return
         end
 
-        context 'with no seasonal pricing defined' do
-          it 'returns the default pricing definition' do
-            expect(subject).to eq(default_definition)
+        context 'when interval provided is not a Date instance' do
+          let(:interval) { 'some random stuff' }
+
+          it 'raises an ArgumentError error' do
+            expect { subject }.to raise_error(ArgumentError)
           end
         end
 
-        context 'with seasonal pricing defined' do
-          let!(:seasonal_definition) { create_definition! priceable: priceable, starts_at: starts, ends_at: ends, weight: 10 }
+        context 'when interval provided is a Date instance' do
+          let(:interval) { Date.new(2016, 01, 01) }
 
-          context 'in the past' do
-            let(:starts) { '2014-12-12' }
-            let(:ends) { '2014-12-30' }
+          context 'and season defined for that interval' do
+            let!(:seasonal_definition) { create_definition!({ priceable: priceable }.merge(seasonal_options)) }
+            let(:seasonal_options) { { starts_at: '2015-12-01', ends_at: '2016-01-01', weight: 100 } }
 
-            it 'does not return the past pricing definition' do
-              expect(subject).to_not eq(seasonal_definition)
+            it 'returns the matching pricing definition' do
+              expect(subject).to eq(seasonal_definition)
             end
           end
 
-          context 'in the present' do
-            let(:starts) { '2015-01-01' }
-            let(:ends) { '2015-01-31' }
-
-            it 'returns the current pricing definition' do
-              expect(subject).to eq(seasonal_definition)
-              expect(subject).to_not eq(default_definition)
+          context 'and season defined for that interval' do
+            it 'returns the default pricing definition' do
+              expect(subject).to eq(default_definition)
             end
+          end
+        end
 
-            context 'that overlap' do
-              let!(:prioritized) { create_definition! priceable: priceable, starts_at: starts, ends_at: ends, weight: 20 }
+        context 'when no interval provided' do
+          let(:interval) { nil }
 
-              it 'returns the prioritized pricing definition' do
-                expect(subject).to eq(prioritized)
+          context 'with no seasonal pricing defined' do
+            it 'returns the default pricing definition' do
+              expect(subject).to eq(default_definition)
+            end
+          end
+
+          context 'with seasonal pricing defined' do
+            let!(:seasonal_definition) { create_definition! priceable: priceable, starts_at: starts, ends_at: ends, weight: 10 }
+
+            context 'in the past' do
+              let(:starts) { '2014-12-12' }
+              let(:ends) { '2014-12-30' }
+
+              it 'does not return the past pricing definition' do
                 expect(subject).to_not eq(seasonal_definition)
               end
             end
-          end
 
-          context 'in the future' do
-            let(:starts) { '2015-02-01' }
-            let(:ends) { '2015-02-28' }
+            context 'in the present' do
+              let(:starts) { '2015-01-01' }
+              let(:ends) { '2015-01-31' }
 
-            it 'does not return the future pricing definition' do
-              expect(subject).to_not eq(seasonal_definition)
+              it 'returns the current pricing definition' do
+                expect(subject).to eq(seasonal_definition)
+                expect(subject).to_not eq(default_definition)
+              end
+
+              context 'that overlap' do
+                let!(:prioritized) { create_definition! priceable: priceable, starts_at: starts, ends_at: ends, weight: 20 }
+
+                it 'returns the prioritized pricing definition' do
+                  expect(subject).to eq(prioritized)
+                  expect(subject).to_not eq(seasonal_definition)
+                end
+              end
+            end
+
+            context 'in the future' do
+              let(:starts) { '2015-02-01' }
+              let(:ends) { '2015-02-28' }
+
+              it 'does not return the future pricing definition' do
+                expect(subject).to_not eq(seasonal_definition)
+              end
             end
           end
         end

--- a/spec/pricing_definition/behaviours/priceable_calculator/instance_methods_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_calculator/instance_methods_spec.rb
@@ -8,11 +8,13 @@ module PricingDefinition
       describe InstanceMethods do
         let(:klass) { ::AcmeOrder }
         let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], priceable_modifiers: [:test_modifier], volume: :quantity, interval_start: :request_date } }
+        let(:business) { double(currency: 'usd', title: 'Business Inc.') }
 
         before(:each) do
+          allow_any_instance_of(klass).to receive(:business).and_return(business)
           klass.priceable_calculator(priceable_calculator_options) do |config|
-            config.add_party :acme_inc, currency: "USD", name: "ACME Inc.", base: true
-            config.add_party :business, currency: :currency, name: :name
+            config.add_party :acme_inc, source: :self, currency: 'eur', type: :charge
+            config.add_party :business, currency: :currency, type: :base
           end
         end
 

--- a/spec/pricing_definition/behaviours/priceable_calculator/instance_methods_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_calculator/instance_methods_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Behaviours
+    module PriceableCalculator
+      describe InstanceMethods do
+        let(:klass) { ::AcmeOrder }
+        let(:instance) { klass.new }
+        let(:priceable_calculator_options) {
+          {
+            priceable: :test_priceable,
+            priceable_addons: [:test_addon],
+            priceable_modifiers: [:test_modifier],
+            volume: :quantity,
+            interval_start: :request_date
+          }
+        }
+
+        before(:each) do
+          klass.priceable_calculator(priceable_calculator_options) do |config|
+            config.add_party :acme_inc, currency: "USD", name: "ACME Inc."
+            config.add_party :business, currency: :business_currency, name: :business_name
+            config.add_party :customer, currencsy: :customer_currency, name: :customer_name
+          end
+        end
+
+        %w(priceable volume interval_start).each do |attr|
+          attr_name = "pricing_#{attr}"
+          describe "#{attr_name}" do
+            subject { instance.send(attr_name) }
+
+            it 'maps it to instance method' do
+              instance_method = priceable_calculator_options[attr.to_sym]
+              expect(subject).to eq(instance.send(instance_method))
+            end
+          end
+        end
+
+        describe '#priceable_calculator_party_modifiers' do
+          subject { instance.priceable_calculator_party_modifiers }
+          let!(:test_modifier) { TestModifier.new }
+
+          before(:each) do
+            allow(instance).to receive(:test_modifier).and_return(test_modifier)
+          end
+
+          it 'returns a hash' do
+            expect(subject).to be_a(Hash)
+          end
+
+          it 'returns a hash with party names as keys' do
+            party_name = subject.keys
+            expect(party_name).to include(:acme_inc)
+            expect(party_name).to include(:business)
+            expect(party_name).to include(:customer)
+          end
+
+          it 'returns a hash with priceable modifiers as values' do
+            expect(subject[:acme_inc]).to include(test_modifier.serialized)
+            expect(subject[:business]).to include(test_modifier.serialized)
+            expect(subject[:customer]).to include(test_modifier.serialized)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pricing_definition/behaviours/priceable_calculator/instance_methods_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_calculator/instance_methods_spec.rb
@@ -7,60 +7,28 @@ module PricingDefinition
     module PriceableCalculator
       describe InstanceMethods do
         let(:klass) { ::AcmeOrder }
-        let(:instance) { klass.new }
-        let(:priceable_calculator_options) {
-          {
-            priceable: :test_priceable,
-            priceable_addons: [:test_addon],
-            priceable_modifiers: [:test_modifier],
-            volume: :quantity,
-            interval_start: :request_date
-          }
-        }
+        let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], priceable_modifiers: [:test_modifier], volume: :quantity, interval_start: :request_date } }
 
         before(:each) do
           klass.priceable_calculator(priceable_calculator_options) do |config|
-            config.add_party :acme_inc, currency: "USD", name: "ACME Inc."
-            config.add_party :business, currency: :business_currency, name: :business_name
-            config.add_party :customer, currencsy: :customer_currency, name: :customer_name
+            config.add_party :acme_inc, currency: "USD", name: "ACME Inc.", base: true
+            config.add_party :business, currency: :currency, name: :name
           end
         end
 
-        %w(priceable volume interval_start).each do |attr|
-          attr_name = "pricing_#{attr}"
-          describe "#{attr_name}" do
-            subject { instance.send(attr_name) }
+        describe '#calculator_config' do
+          subject { klass.new.calculator_config }
 
-            it 'maps it to instance method' do
-              instance_method = priceable_calculator_options[attr.to_sym]
-              expect(subject).to eq(instance.send(instance_method))
-            end
+          it 'returns class configuration for priceable_calculator behaviour' do
+            expect(subject).to eq(klass.priceable_calculator_config)
           end
         end
 
-        describe '#priceable_calculator_party_modifiers' do
-          subject { instance.priceable_calculator_party_modifiers }
-          let!(:test_modifier) { TestModifier.new }
+        describe '#calculator' do
+          subject { klass.new.calculator }
 
-          before(:each) do
-            allow(instance).to receive(:test_modifier).and_return(test_modifier)
-          end
-
-          it 'returns a hash' do
-            expect(subject).to be_a(Hash)
-          end
-
-          it 'returns a hash with party names as keys' do
-            party_name = subject.keys
-            expect(party_name).to include(:acme_inc)
-            expect(party_name).to include(:business)
-            expect(party_name).to include(:customer)
-          end
-
-          it 'returns a hash with priceable modifiers as values' do
-            expect(subject[:acme_inc]).to include(test_modifier.serialized)
-            expect(subject[:business]).to include(test_modifier.serialized)
-            expect(subject[:customer]).to include(test_modifier.serialized)
+          it 'returns an instance of Helpers::Calculator' do
+            expect(subject).to be_a(Helpers::Calculator)
           end
         end
       end

--- a/spec/pricing_definition/behaviours/priceable_calculator_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_calculator_spec.rb
@@ -20,7 +20,7 @@ module PricingDefinition
 
           context 'without required attributes' do
             subject { klass.priceable_calculator(priceable_calculator_options) { } }
-            let(:priceable_calculator_options) { { priceable: [:test_priceable], priceable_addons: [:test_addon], volume: :some_quantity, interval_start: :some_request_date } }
+            let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], priceable_modifiers: [:test_modifier], volume: :some_quantity, interval_start: :some_request_date } }
 
             it 'raises an error' do
               expect(klass.attribute_names).to_not include("some_quantity")
@@ -38,7 +38,7 @@ module PricingDefinition
             end
 
             let(:behaviour) { PricingDefinition::Configuration.behaviour_for(klass) }
-            let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], volume: :quantity, interval_start: :request_date } }
+            let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], priceable_modifiers: [:test_modifier], volume: :quantity, interval_start: :request_date } }
 
             it 'does not raise an error' do
               expect { subject }.to_not raise_error

--- a/spec/pricing_definition/behaviours/priceable_calculator_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_calculator_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Behaviours
+    describe PriceableCalculator do
+      let(:klass) { ::AcmeOrder }
+
+      context 'extending model' do
+        subject { klass.priceable_calculator(priceable_calculator_options) { } }
+
+        context 'options' do
+          context 'without allowed option keys' do
+            let(:priceable_calculator_options) { { some: :random, option: :config } }
+            it 'raises an error' do
+              expect { subject }.to raise_error
+            end
+          end
+
+          context 'without required attributes' do
+            let(:priceable_calculator_options) {
+              {
+                priceable: [:test_priceable],
+                priceable_addons: [:test_addon],
+                volume: :some_quantity,
+                interval_start: :some_request_date
+              }
+            }
+
+            it 'raises an error' do
+              expect(klass.attribute_names).to_not include("some_quantity")
+              expect(klass.attribute_names).to_not include("some_request_date")
+              expect { subject }.to raise_error
+            end
+          end
+
+          context 'with allowed option keys and valid required attributes' do
+            let(:behaviour) { PricingDefinition::Configuration.behaviour_for(klass) }
+            let(:priceable_calculator_options) {
+              {
+                priceable: :test_priceable,
+                priceable_addons: [:test_addon],
+                volume: :quantity,
+                interval_start: :request_date
+              }
+            }
+
+            it 'does not raise an error' do
+              expect { subject }.to_not raise_error
+            end
+
+            it 'adds configuration for priceable calculators' do
+              subject
+              expect(behaviour).to eq(:priceable_calculator)
+            end
+
+            it 'associates model with PriceDefinition::Resources::Payment' do
+              subject
+              association = klass.reflect_on_association(:pricing_payment)
+              expect(association.macro).to eq(:has_one)
+              expect(association.options[:dependent]).to eq(:nullify)
+              expect(association.options[:as]).to eq(:priceable_calculator)
+            end
+
+            context 'configuration block' do
+              context 'when not given' do
+                subject { klass.priceable_calculator(priceable_calculator_options) }
+
+                it 'raises an error' do
+                  expect { subject }.to raise_error
+                end
+              end
+
+              context 'when given' do
+                subject { klass.priceable_calculator(priceable_calculator_options, &config_block) }
+                let(:config_block) { proc { |c| c.add_party(party_name, party_args) } }
+                let(:party_name) { :acme_inc }
+                let(:party_args) { { currency: "USD", name: "ACME Inc." } }
+
+                it 'does not raise an error' do
+                  expect { subject }.to_not raise_error
+                end
+
+                it 'sets up priceable calculator configuration' do
+                  expect(PriceableCalculator::SetupMethods::Configure).to receive(:add_party).with(party_name, party_args)
+                  subject
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pricing_definition/behaviours/priceable_modifier_spec.rb
+++ b/spec/pricing_definition/behaviours/priceable_modifier_spec.rb
@@ -12,7 +12,7 @@ module PricingDefinition
         context 'with invalid option keys' do
           let(:options) { { unsupported: :configuration } }
 
-          it 'does not raise an error' do
+          it 'raises an error' do
             expect { subject }.to raise_error
           end
         end

--- a/spec/pricing_definition/configuration_spec.rb
+++ b/spec/pricing_definition/configuration_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module PricingDefinition
   describe Configuration do
     before(:each) do
-      expect(Configuration::SUPPORTED_BEHAVIOURS).to eq([:priceable, :priceable_modifier])
+      expect(Configuration::SUPPORTED_BEHAVIOURS).to eq([:priceable, :priceable_modifier, :priceable_calculator])
     end
 
     describe '.config' do
@@ -50,7 +50,7 @@ module PricingDefinition
 
     describe '.behaviour_for' do
       subject { Configuration.behaviour_for(klass) }
-      let(:config) { Configuration::Setup.new(priceables: [config_entry], priceable_modifiers: []) }
+      let(:config) { Configuration::Setup.new(priceables: [config_entry], priceable_modifiers: [], priceable_calculators: []) }
       let(:config_entry) { Configuration::SetupEntry.new(resource: String) }
 
       before(:each) do
@@ -76,7 +76,7 @@ module PricingDefinition
 
     describe '.behaviour_for?' do
       subject { Configuration.behaviour_for?(klass, behaviour_type) }
-      let(:config) { Configuration::Setup.new(priceables: [config_entry], priceable_modifiers: []) }
+      let(:config) { Configuration::Setup.new(priceables: [config_entry], priceable_modifiers: [], priceable_calculators: []) }
       let(:config_entry) { Configuration::SetupEntry.new(resource: klass) }
       let(:klass) { String }
 

--- a/spec/pricing_definition/helpers/calculator/party_spec.rb
+++ b/spec/pricing_definition/helpers/calculator/party_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Helpers
+    class Calculator
+      describe Party do
+        let(:party) { Party.new(resource, options) }
+        let(:resource) { ::AcmeOrder.new }
+        let(:options) { { name: :acme_inc, title: title, currency: currency, type: type } }
+        let(:title) { "ACME Inc." }
+        let(:currency) { "USD" }
+        let(:type) { :charge }
+
+        [:charge, :base].each do |method|
+          describe "##{method}?" do
+            subject { party.send("#{method}?") }
+
+            context "with #{method} type" do
+              let(:type) { method }
+              it 'returns true' do
+                expect(subject).to eq(true)
+              end
+            end
+
+            context "without :#{method} type" do
+              let(:type) { "random" }
+              it 'returns false' do
+                expect(subject).to eq(false)
+              end
+            end
+          end
+        end
+
+        [:currency, :title].each do |attr|
+          describe "##{attr}" do
+            subject { party.send(attr) }
+
+            context "with string for :#{attr} value" do
+              let(attr) { "some string" }
+              it "returns string provided"do
+                expect(subject).to eq("some string")
+              end
+            end
+
+            context "with symbol for :#{attr} value" do
+              let(attr) { :some_method }
+              context "and resource responds to method" do
+                it "returns the result of the method"do
+                  allow(resource).to receive(send(attr)).and_return("EUR")
+                  expect(subject).to eq("EUR")
+                end
+              end
+
+              context "and resource does not respond to method" do
+                it "returns the result of the method"do
+                  expect { subject }.to raise_error
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pricing_definition/helpers/calculator/pricing_rule_spec.rb
+++ b/spec/pricing_definition/helpers/calculator/pricing_rule_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Helpers
+    class Calculator
+      describe PricingRule do
+        let(:pricing_rule) { PricingRule.new(pricing_for_volume) }
+        let(:pricing) { create_definition! definition: definition }
+        let(:pricing_for_volume) { pricing.for_volume(volume) }
+        let(:volume) { 8 }
+        let(:currency) { :usd }
+        let(:definition) {
+          {
+            '1+' => { fixed: false, price: { adults: 1000, children: 800 }, deposit: 0 },
+            '2..4' => { fixed: false, price: { adults: 900, children: 700 }, deposit: 100 },
+            '5..8' => { fixed: false, price: { adults: 800, children: 600 }, deposit: 200 },
+            '9+' => { fixed: true, price: { fixed: 50000 }, deposit: 2000 }
+          }
+        }
+
+        before(:each) do
+          allow(pricing.priceable).to receive(:currency).and_return(currency)
+        end
+
+        describe '#prices' do
+          subject { pricing_rule.prices }
+
+          it 'returns a hash with moenu' do
+            expect(subject[:adults]).to eq(Money.new(800, currency))
+            expect(subject[:children]).to eq(Money.new(600, currency))
+          end
+        end
+
+        describe '#deposit' do
+          subject { pricing_rule.deposit }
+          let(:volume) { 20 }
+
+          it 'returns a hash with moenu' do
+            expect(subject).to eq(Money.new(2000, currency))
+          end
+        end
+
+        describe '#fixed?' do
+          subject { pricing_rule.fixed? }
+
+          context 'with fixed pricing' do
+            let(:volume) { 1 }
+
+            it 'returns false' do
+              expect(subject).to eq(false)
+            end
+          end
+
+          context 'without fixed pricing' do
+            let(:volume) { 12 }
+
+            it 'returns true' do
+              expect(subject).to eq(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/pricing_definition/helpers/calculator_spec.rb
+++ b/spec/pricing_definition/helpers/calculator_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'support/active_record'
+require 'support/helpers'
+
+module PricingDefinition
+  module Helpers
+    describe Calculator do
+      let(:calculator) { PricingDefinition::Helpers::Calculator.new(acme_order) }
+      let(:acme_order) { ::AcmeOrder.new }
+      let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], priceable_modifiers: [:test_modifier], volume: :quantity, interval_start: :request_date } }
+
+      before(:each) do
+        ::AcmeOrder.priceable_calculator(priceable_calculator_options) do |config|
+          config.add_party :acme_inc, currency: "USD", name: "ACME Inc.", base: true
+          config.add_party :business, currency: :currency, name: :name
+        end
+      end
+
+      describe '#resource' do
+        subject { calculator.resource }
+
+        it 'returns the object with which it was initialized' do
+          expect(subject).to eq(acme_order)
+        end
+      end
+
+      describe '#pricing_definition' do
+        subject { calculator.pricing_definition }
+        let(:pricing_definition) { create_definition! }
+        let(:priceable) { pricing_definition.priceable }
+
+        before(:each) do
+          allow(acme_order).to receive(:test_priceable).and_return(priceable)
+          allow(priceable).to receive(:pricing_definition).and_return(pricing_definition)
+        end
+
+        it 'returns the pricing definition for priceable' do
+          expect(subject).to eq(pricing_definition)
+        end
+      end
+
+      describe '#priceable' do
+        subject { calculator.priceable }
+        let(:test_priceable) { ::TestPriceable.new }
+
+        it 'returns the associated priceable object' do
+          allow(acme_order).to receive(:test_priceable).and_return(test_priceable)
+          expect(subject).to eq(acme_order.test_priceable)
+        end
+      end
+
+      describe '#parties' do
+        subject { calculator.parties }
+
+        it 'returns the partires with their configuration' do
+          expect(subject[:acme_inc]).to include(currency: "USD", name: "ACME Inc.", base: true)
+          expect(subject[:business]).to include(currency: :currency, name: :name)
+        end
+      end
+
+      describe '#modifiers' do
+        subject { calculator.modifiers }
+        let!(:test_modifier) { ::TestModifier.new }
+
+        before(:each) do
+          allow(acme_order).to receive(:test_modifier).and_return(test_modifier)
+        end
+
+        it 'returns a collection of all defined modifiers' do
+          expect(subject).to include(test_modifier)
+        end
+      end
+
+      describe '#parties_modifiers' do
+        subject { calculator.parties_modifiers }
+        let!(:modifier) { ::TestModifier.new }
+
+        before(:each) do
+          allow(calculator).to receive(:modifiers).and_return([modifier])
+        end
+
+        context 'when resource does not define :parties_modifiers' do
+          it 'returns its value' do
+            modifiers = { acme_inc: [modifier] }
+            allow(acme_order).to receive(:parties_modifiers).and_return(modifiers)
+            expect(acme_order).to respond_to(:parties_modifiers)
+            expect(subject).to eq(modifiers)
+          end
+        end
+
+        context 'when resource does not define :parties_modifiers' do
+          it 'contains parties names as keys and #modifiers as values' do
+            expect(calculator.resource).to_not respond_to(:parties_modifiers)
+            expect(subject.keys).to include(:acme_inc, :business)
+            expect(subject[:acme_inc]).to eq(calculator.modifiers)
+            expect(subject[:business]).to eq(calculator.modifiers)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pricing_definition/helpers/calculator_spec.rb
+++ b/spec/pricing_definition/helpers/calculator_spec.rb
@@ -5,19 +5,18 @@ require 'support/helpers'
 module PricingDefinition
   module Helpers
     describe Calculator do
+      let(:acme_order) { klass.new }
+      let(:business) { double(currency: 'usd', title: 'Business Inc.') }
       let(:calculator) { PricingDefinition::Helpers::Calculator.new(acme_order) }
-      let(:acme_order) { ::AcmeOrder.new }
+      let(:klass) { ::AcmeOrder }
       let(:priceable_calculator_options) { { priceable: :test_priceable, priceable_addons: [:test_addon], priceable_modifiers: [:test_modifier], volume: :quantity, interval_start: :request_date } }
 
       before(:each) do
-        ::AcmeOrder.priceable_calculator(priceable_calculator_options) do |config|
-          config.add_party :acme_inc, currency: "USD", type: :charge
+        allow(acme_order).to receive(:business).and_return(business)
+        klass.priceable_calculator(priceable_calculator_options) do |config|
+          config.add_party :acme_inc, source: :self, currency: 'eur', type: :charge
           config.add_party :business, currency: :currency, type: :base
         end
-      end
-
-      describe '#initialize' do
-        subject { Calculator.new(acme_order) }
       end
 
       describe '#resource' do
@@ -92,8 +91,8 @@ module PricingDefinition
 
       describe '#parties' do
         subject { calculator.parties }
-        let(:acme_inc_party) { Calculator::Party.new(acme_order, name: :acme_inc, type: :charge, currency: "USD") }
-        let(:business_party) { Calculator::Party.new(acme_order, name: :business, type: :base, currency: :currency) }
+        let(:acme_inc_party) { Calculator::Party.new(acme_order, name: :acme_inc, source: :self, currency: 'eur', type: :charge) }
+        let(:business_party) { Calculator::Party.new(business, name: :business, type: :base, currency: :currency) }
 
         it 'returns the a collection of Calculator::Party instances' do
           expect(subject).to include(acme_inc_party)

--- a/spec/pricing_definition/helpers/calculator_spec.rb
+++ b/spec/pricing_definition/helpers/calculator_spec.rb
@@ -49,6 +49,32 @@ module PricingDefinition
         end
       end
 
+      describe '#charge_currency' do
+        subject { calculator.charge_currency }
+
+        it 'returns the currency of the charge party' do
+          expect(subject).to eq('eur')
+        end
+      end
+
+      describe '#base_currency' do
+        subject { calculator.base_currency }
+        let(:business) { double(currency: currency) }
+        let(:currency) { 'gbp' }
+
+        it 'returns the currency of the base party' do
+          expect(subject).to eq(currency)
+        end
+      end
+
+      describe '#currencies' do
+        subject { calculator.currencies }
+
+        it 'returns a collection containing all involved currencies' do
+          expect(subject).to include(:eur, :usd)
+        end
+      end
+
       describe '#priceable' do
         subject { calculator.priceable }
         let(:test_priceable) { ::TestPriceable.new }

--- a/spec/pricing_definition/helpers/calculator_spec.rb
+++ b/spec/pricing_definition/helpers/calculator_spec.rb
@@ -49,6 +49,29 @@ module PricingDefinition
         end
       end
 
+      describe '#pricing_rule' do
+        subject { calculator.pricing_rule }
+        let(:pricing) { create_definition! definition: definition }
+        let(:overall_volume) { 8 }
+        let(:definition) {
+          {
+            '1+' => { fixed: false, price: { adults: 1000, children: 800 }, deposit: 0 },
+            '2..4' => { fixed: false, price: { adults: 900, children: 700 }, deposit: 100 },
+            '5..8' => { fixed: false, price: { adults: 800, children: 600 }, deposit: 200 },
+            '9+' => { fixed: true, price: { fixed: 50000 }, deposit: 2000 }
+          }
+        }
+
+        it 'returns rule for matching volume' do
+          allow(calculator).to receive(:pricing_definition).and_return(pricing)
+          allow(calculator).to receive(:overall_volume).and_return(overall_volume)
+          rule = subject[:pricing]
+          expect(rule[:fixed]).to eq(false)
+          expect(rule[:price]).to include(adults: 800, children: 600)
+          expect(rule[:deposit]).to eq(200)
+        end
+      end
+
       describe '#charge_currency' do
         subject { calculator.charge_currency }
 

--- a/spec/pricing_definition/helpers/calculator_spec.rb
+++ b/spec/pricing_definition/helpers/calculator_spec.rb
@@ -90,14 +90,6 @@ module PricingDefinition
         end
       end
 
-      describe '#currencies' do
-        subject { calculator.currencies }
-
-        it 'returns a collection containing all involved currencies' do
-          expect(subject).to include(:eur, :usd)
-        end
-      end
-
       describe '#priceable' do
         subject { calculator.priceable }
         let(:test_priceable) { ::TestPriceable.new }

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -15,6 +15,15 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :pricing_payments, force: true do |t|
+    t.integer :priceable_calculator_id
+    t.string :priceable_calculator_type
+    t.timestamps null: false
+  end
+
+  add_index :pricing_payments, [:priceable_calculator_id, :priceable_calculator_type], name: 'pricing_payments_calculator_poly_index'
+
+  # NOTE these are used only in specs
   create_table :test_priceables, force: true do |t|
     t.string :currency, default: nil
     t.integer :min_limit, default: 1
@@ -30,9 +39,21 @@ ActiveRecord::Schema.define do
     t.boolean :additive, default: false
     t.boolean :fixed, default: false
     t.integer :amount, default: 1
+    t.string :label
+    t.string :description
     t.string :currency
     t.timestamps null: false
   end
+
+  create_table :acme_orders, force: true do |t|
+    t.integer :quantity, default: 0
+    t.integer :test_priceable_id
+    t.integer :modifier_with_required_attribute_id
+    t.date :request_date
+    t.timestamps null: false
+  end
+  add_index :acme_orders, :test_priceable_id
+  add_index :acme_orders, :modifier_with_required_attribute_id
 end
 
 RSpec.configure do |config|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,6 +1,6 @@
 class TestPriceable < ActiveRecord::Base
   include PricingDefinition::Behaviours::Priceable
-  priceable
+  priceable currency: :currency
 end
 
 class Priceable < ActiveRecord::Base

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -36,3 +36,20 @@ end
 class ModifierWithRequiredAttributes < ActiveRecord::Base
   include PricingDefinition::Behaviours::PriceableModifier
 end
+
+class TestModifier < ActiveRecord::Base
+  self.table_name = :modifier_with_required_attributes
+  include PricingDefinition::Behaviours::PriceableModifier
+  priceable_modifier for: :test_priceable, weight: 10, label: :label, description: :description
+end
+
+class AcmeOrder < ActiveRecord::Base
+  include PricingDefinition::Behaviours::PriceableCalculator
+
+  belongs_to :test_priceable
+  belongs_to :test_modifier
+
+  def test_addon
+
+  end
+end


### PR DESCRIPTION
### Abstract

We need a new behaviour for the `pricing_definition` gem that will be called `priceable_calculator` and will be used for making `ActiveRecord` models to behave like an _endpoint_ for _priceable_ models. By _endpoint_ we mean _an entity_ or _a part of an application_ (name it as you please) that will be responsible for handling and storing all information needed for calculating the cost for a priceable object based on a set of conditions (by conditions we refer to volume, priceable addons and priceable modifiers that may apply to a priceable object).
### Needs
- [x] We need to be able to [define](https://github.com/anyroadcom/pricing_definition/blob/27704089e990248445c7307a3ba6de52d6a36590/lib/pricing_definition/behaviours/priceable_calculator/setup_methods.rb) the parties that take part in a transaction for a priceable object. The involved parties, for example could consist of the _customer_ (that purchases a service), the _business_ (that provides the service) and the _acme_inc_ (via whom the service is purchased) but it could be anything that reflects our business model. When defining a party we need to be able to provide a:
  - [x] Symbol identifier for it (in our example `:acme_inc`, `:business`, `:customer`)
  - [x] `:source` attribute for declaring which [object](https://github.com/anyroadcom/pricing_definition/blob/27704089e990248445c7307a3ba6de52d6a36590/lib/pricing_definition/helpers/calculator.rb#L92) should be used for retrieving party information.  
  - [x] `:type` attribute for each party. For now we need to support `:base` and `:charge` types. This is going to be used internally by the calculator for managing currency conversions and various other operations, yet to be defined
  - [x] Hash of options that will be used for [delegating](https://github.com/anyroadcom/pricing_definition/blob/27704089e990248445c7307a3ba6de52d6a36590/lib/pricing_definition/helpers/calculator/party.rb#L21) messages to the `:source` of the party
- [ ] We need to be able to access all [information](https://github.com/anyroadcom/pricing_definition/blob/27704089e990248445c7307a3ba6de52d6a36590/lib/pricing_definition/helpers/calculator.rb#L35) that will be used to calculate the various costs for a priceable object. These information include the following sections:
  - [x] requested _volume_ **(mandatory)**
  - [x] priceable _pricing definition_  that applies **(mandatory)**
  - [ ] priceable addons' _pricing definition_ that apply **(optional)** 
  - [x] priceable modifiers that apply (if any) **(optional)** 
  - [x] requested _interval_ **(optional)**
  
  We need to be able to serialize and access this information within the instance methods of the model.
- [ ] We need to calculate costs individually for each _party_ defined. The calculations must be diversified in the sense of: 
  - using different currency for _any_ of the involved parties (e.g. the _customer_ purchases in USD while the business requires payments in EUR)
  - applying modifiers to _all_ or _some_ of the involved parties, the modifiers could  (e.g. the _customer_ purchases using a discount that should not affect the calculations for the _business_ but should affect the ones for the _host_
  
  For this reason we need to be able to serialize and access information that could diversify the cost for a party based on logic that will be implemented by **the model we are extending**.
### Proposed API

``` ruby
class AcmeToolOrder

  PRICEABLE_CALCULATOR_OPTIONS = {
    priceables: [:acme_tool],
    priceable_addons: [:acme_tool_addons],
    volume: :quantity,
    interval_start: :request_date
  }.freeze

  belongs_to :business
  belongs_to :customer
  belongs_to :acme_tool # priceable
  belongs_to :acme_discount # priceable modifier
  belongs_to :acme_vat # priceable modifier

  include PricingDefinition::Behaviours::PriceableCalculator

  priceable_calculator(PRICEABLE_CALCULATOR_OPTIONS) do |config|
    config.add_party :acme_inc, source: :self, currency: 'eur', type: :charge
    config.add_party :business, currency: :currency, type: :base
    config.add_party :customer, currency: :customer_currency
  end
end
```

> To be spec'ed further
